### PR TITLE
Changing to 6.x version of Perl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 *~
+**/.precomp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Grammar::EBNF
+# Grammar::EBNF
 
 This module will provide a way for you to use a EBNF grammar natively
 in Perl 6 without the need to translate the rules into Perl 6

--- a/lib/Grammar/EBNF.pm
+++ b/lib/Grammar/EBNF.pm
@@ -1,6 +1,9 @@
 use Grammar::EBNF::MetaSyntax;
 use Grammar::EBNF::Actions;
 use QAST:from<NQP>;
+use nqp;
+use MONKEY-SEE-NO-EVAL;
+
 sub EXPORT(|) {
     my sub lk(Mu \h, \k) {
         nqp::atkey(nqp::findmethod(h, 'hash')(h), k)

--- a/lib/Grammar/EBNF/Actions.pm
+++ b/lib/Grammar/EBNF/Actions.pm
@@ -1,4 +1,5 @@
 use QAST:from<NQP>;
+
 class Grammar::EBNF::Actions {
   method main_syntax(Mu $/ is rw) {
     my %rules;
@@ -60,7 +61,7 @@ class Grammar::EBNF::Actions {
       $/.make($<terminal_string>.made);
     } elsif ($<meta_identifier>) {
       my $name = $<meta_identifier>.made;
-      my $faux_regex = -> $invocant: *@args {
+      my $faux_regex = -> $invocant, *@args {
         $invocant."$name"(|@args);
       };
       $/.make('<'~$name~'>');

--- a/t/001_simple_grammar.t
+++ b/t/001_simple_grammar.t
@@ -25,4 +25,4 @@ numberZero = "0";
 letterA = "a";
 ', 'two rules in TOP with newlines');
 is($g.parse('{ ExternalDeclaration }', :rule<definitions_list>), '{ ExternalDeclaration }', 'repetition');
-done()
+done-testing;

--- a/t/002_parse_tree.t
+++ b/t/002_parse_tree.t
@@ -16,4 +16,4 @@ is($m{"main_syntax"}{"syntax_rule"}[1]{"definitions_list"}, '"a"', "second defin
 is($m{"main_syntax"}{"syntax_rule"}[0]{"definitions_list"}{"single_definition"}, '"0"', "first single definition");
 is($m{"main_syntax"}{"syntax_rule"}[1]{"definitions_list"}{"single_definition"}, '"a"', "second single definition");
 
-done()
+done-testing;

--- a/t/003_ansi_c.t
+++ b/t/003_ansi_c.t
@@ -7,4 +7,4 @@ my $m = Grammar::EBNF::MetaSyntax.parsefile("t/003_ansi_c.ebnf")
 is($m{"main_syntax"}{"syntax_rule"}.elems, 129, "129 rules");
 ok($m{"main_syntax"}{"syntax_rule"}.grep({$_{"meta_identifier"} eq "Pointer"}), "Find the pointer rule");
 
-done();
+done-testing;

--- a/t/004_slang.t
+++ b/t/004_slang.t
@@ -11,4 +11,4 @@ ok(A::B.parse("42"), "Parse succeeds");
 ok(!A::B.parse("2"), "Parse fails when it doesn't match");
 ok(A::B.parse("2", :rule<a>), "Parse succeeds");
 ok(!A::B.parse("42", :rule<a>), "Parse fails when it doesn't match");
-done();
+done-testing;

--- a/t/005_alternation.t
+++ b/t/005_alternation.t
@@ -8,4 +8,4 @@ ok(A::B.parse("42"), "Parse succeeds");
 ok(A::B.parse("2"), "Parse succeeds");
 ok(!A::B.parse("3"), "Parse fails when it doesn't match");
 ok(!A::B.parse("43"), "Parse fails when it doesn't match");
-done();
+done-testing;

--- a/t/006_subrule.t
+++ b/t/006_subrule.t
@@ -9,4 +9,4 @@ my $m = A::B.parse("2")
   or die "Parse fails, aborting remaining tests";
 is($m<a>, "2", "Generates a parse tree");
 
-done();
+done-testing;

--- a/t/007_concatenation.t
+++ b/t/007_concatenation.t
@@ -6,4 +6,4 @@ ebnf-grammar A::B {
 ok(!A::B.parse("32"), "Parse fails when it doesn't match");
 ok(A::B.parse("23"), "Parse succeeds when it matches");
 
-done();
+done-testing;

--- a/t/008_simple_repetition.t
+++ b/t/008_simple_repetition.t
@@ -11,4 +11,4 @@ ok(A::B.parse("2333"), "Matches with 3 occurrences");
 ok(A::B.parse("23333"), "Matches with 4 occurrences");
 ok(!A::B.parse("23334"), "Fails when wrong character after 3 occurrences");
 
-done();
+done-testing;


### PR DESCRIPTION
But I have bumped into a few problems I can't really fathom.
First, this one:
~~~
EVAL is a very dangerous function!!! (use the MONKEY-SEE-NO-EVAL pragma to override this error,
but only if you're VERY sure your data contains no injection attacks)
~~~
I have added the pragma, but I'm not so sure the data contains no injection attack.
Then, finally, this one:
~~~
===SORRY!===
Cannot invoke this object (REPR: Null; VMNull)
t/004_slang.t ................. Dubious, test returned 1
No subtests run
===SORRY!===
Cannot invoke this object (REPR: Null; VMNull)
t/005_alternation.t ........... Dubious, test returned 1
No subtests run
===SORRY!===
Cannot invoke this object (REPR: Null; VMNull)
t/006_subrule.t ............... Dubious, test returned 1
No subtests run
===SORRY!===
Cannot invoke this object (REPR: Null; VMNull)
t/007_concatenation.t ......... Dubious, test returned 1
No subtests run
===SORRY!===
Cannot invoke this object (REPR: Null; VMNull)
t/008_simple_repetition.t ..... Dubious, test returned 1
No subtests run
===SORRY!===
Cannot invoke this object (REPR: Null; VMNull)
t/009_grouping.t .............. Dubious, test returned 1
No subtests run
===SORRY!===
Cannot invoke this object (REPR: Null; VMNull)
t/010_more_complex_example.t .. Dubious, test returned 1
~~~
I wonder if it's got to do something with the fact you're using `nqp`. Anyway, at least some tests pass now :-) Thanks for your work.